### PR TITLE
Add adonis-serverless repository to tutorials list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 
 - [Adonis V5 (MongoDB) provider](https://mcsneaky.ap3k.pro/posts/adonis-v5-provider/) - An article covering how to use MongoDB in your AdonisJS projects
 - [Set up TailwindCSS using the default Encore package](https://ivanprats.dev/blog/set-up-tailwindcss-in-new-adonis5/) - A quick article explaining what dependencies to install and configuration to add to set up TailwindCSS in a Adonis 5 application, using the default Webpack Encore package for assets management.
+- [Adonis V5 serverless on AWS Lambda](https://github.com/tomhatzer/adonis-serverless) - This is an example repository for running AdonisJS V5 serverless on AWS Lambda.
 
 ## Videos and courses
 


### PR DESCRIPTION
- [x] I have read the [contributing guide](https://github.com/adonisjs-community/awesome-adonisjs/blob/master/CONTRIBUTING.md) before creating this PR.

This PR adds a link to the tomhatzer/adonis-serverless github repository that includes all that's necessary to run Adonis v5 serverless on AWS Lambda.

Thank you!