### PR TITLE
docs: add AdonisJS Lucid Zero Adapter, Generator, and Ally Slack driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ _We would like to thank [Zura Gabievi](https://github.com/zgabievi) for maintain
 - [AdonisJS Lucid Zero Adapter](https://github.com/antislophq/zero-lucid) - AdonisJS Lucid adapter for rocicorp/zero
 - [AdonisJS Lucid Zero Generator](https://github.com/antislophq/zero-lucid-generator) - Generate rocicorp/zero schemas from Lucid ORM schemas.
 - [AdonisJS Ally Slack](https://github.com/antislophq/ally-slack-driver) - A Slack driver for AdonisJS Ally
+- [AdonisJS Japa JUnit Reporter](https://github.com/antislophq/japa-junit-reporter) - A JUnit reporter for AdonisJS Japa
 
 ## Articles, tutorials, and blog posts
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ _We would like to thank [Zura Gabievi](https://github.com/zgabievi) for maintain
 - [AdonisJS Ally Microsoft](https://github.com/ThibaultPointurier/ally-microsoft) - A Microsoft driver for AdonisJS Ally
 - [AdonisJS Ally Patreon](https://github.com/ThibaultPointurier/ally-patreon) - A Patreon driver for AdonisJS Ally
 - [AdonisJS Mercure](https://github.com/mdsiha/adonis-mercure) - Mercure Hub integration for AdonisJS v6 — real-time updates via Server-Sent Events (SSE)
+- [AdonisJS Lucid Zero Adapter](https://github.com/antislophq/zero-lucid) - AdonisJS Lucid adapter for rocicorp/zero
+- [AdonisJS Lucid Zero Generator](https://github.com/antislophq/zero-lucid-generator) - Generate rocicorp/zero schemas from Lucid ORM schemas.
+- [AdonisJS Ally Slack](https://github.com/antislophq/ally-slack-driver) - A Slack driver for AdonisJS Ally
 
 ## Articles, tutorials, and blog posts
 


### PR DESCRIPTION
**Packages**

- [AdonisJS Lucid Zero Adapter](https://github.com/antislophq/zero-lucid) - AdonisJS Lucid adapter for rocicorp/zero
- [AdonisJS Lucid Zero Generator](https://github.com/antislophq/zero-lucid-generator) - Generate rocicorp/zero schemas from Lucid ORM schemas.
- [AdonisJS Ally Slack](https://github.com/antislophq/ally-slack-driver) - A Slack driver for AdonisJS Ally
- [AdonisJS Japa JUnit Reporter](https://github.com/antislophq/japa-junit-reporter) - A JUnit reporter for AdonisJS Japa

---

**Checklist**

- [x] I have read the [contributing guide](https://github.com/adonisjs-community/awesome-adonisjs/blob/master/CONTRIBUTING.md) before creating this PR.
- [x] The package has a README covering installation and usage
- [x] Compatible with the latest AdonisJS version (v6)
- [x] Not already listed
- [x] No open PR for the same packag
